### PR TITLE
Actually pass a task to the callback

### DIFF
--- a/src/Native/TaskTutorial.js
+++ b/src/Native/TaskTutorial.js
@@ -22,7 +22,7 @@ Elm.Native.TaskTutorial.make = function(localRuntime) {
 
 
 	var getCurrentTime = Task.asyncFunction(function(callback) {
-		return callback(Date.now());
+		return callback(Task.succeed(Date.now()));
 	});
 
 


### PR DESCRIPTION
`andThen` is broken if you don't pass tasks to callbacks.
