### PR TITLE
Enlarge version bounds for Elm 0.16.

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -11,7 +11,7 @@
     ],
     "native-modules": true,
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 3.0.0"
+        "elm-lang/core": "2.0.0 <= v < 4.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.16.0"
+    "elm-version": "0.15.0 <= v < 0.17.0"
 }


### PR DESCRIPTION
My [elm-http-decorators](https://github.com/rgrempel/elm-http-decorators) module relies on task-tutorial for `getCurrentTime`. So, I would find it helpful it task-tutorial were updated for Elm 0.16. I did a minimal test of it with 0.16, and it seems to continue to work.

Alternatively, you could take a look at [adding `getCurrent` to the `Time` module](https://github.com/elm-lang/core/pull/357)
